### PR TITLE
XML z rozdziałami

### DIFF
--- a/test_tidy.py
+++ b/test_tidy.py
@@ -1,0 +1,27 @@
+from io import StringIO
+
+from tidy import TextTidy
+
+
+def test_001():
+    output = StringIO()
+
+    with open('tests/fixtures/test_001.txt', mode='rb') as fp:
+        TextTidy(_in=fp, chapter_break='\n\n__CHAPTER__\n').tidy(output=output)
+
+    print (output.getvalue())
+
+
+def test_002():
+    output = StringIO()
+
+    with open('publications/106644/issues/2001/168143.txt', mode='rb') as fp:
+    # with open('tests/fixtures/test_002.txt', mode='rb') as fp:
+        TextTidy(_in=fp, chapter_break='\n\n__CHAPTER__\n').tidy(output=output)
+
+    print (output.getvalue())
+
+
+if __name__ == "__main__":
+    # test_001()
+    test_002()

--- a/tests/fixtures/test_001.txt
+++ b/tests/fixtures/test_001.txt
@@ -1,0 +1,85 @@
+52 S. Dygat, op. cit., k. 15-16. Mniemanie Zakrzewskiego o wyższości chirurgii fran- 
+cuskiej nad niemiecką w początkach XX wieku wynikało najprawdopodobniej z jego an- 
+tyniemieckich uprzedzeń i nie odpowiadało stanowi faktycznemu. Na temat ojca Dyga- 
+
+150 
+Włodzimierz Witczak 
+tówny ijego koneksji rodzinnych zob. A. Lewak, Dygat Ludwik (1839-1901), uczestnik po- 
+wstania styczniowego, działacz narodowy na emigracji, PSB, T. VI, Kraków 1948, 
+s. 52-53. 
+53 Archiwum Miasta Poznania, Kartoteka ewidencji ludności, sygn. 15292; Z. Zakrzewski, 
+Wspominam..., s. 11 (data ślubu - 1905 r.); tenże, Ulicami..., s. 160; S. Dygat, op. cit., k. 1,15 
+(ta sama data roczna), k. 53 (sprzeciw Ksawerego Zakrzewskiego wobec zapisania imienia 
+naj starszego syna przez niemieckiego urzędnika stanu cywilnego w formie "Janusch" - 
+tak w Kartotece ewidencji ludności, sygn. 15292); zob. też: T. Smiełowski, Pamięci profesora 
+Zbigniewa Zakrzewskiego, "Kronika Miasta Poznania", 1992, nr 3-4, s. 332-333. 
+54 Z. Zakrzewski, Wspominam..., ss. 12 i 14. 
+55 Archiwum Miasta Poznania, Kartoteka ewidencji ludności, sygn. 15292; Z. Zakrzewski, 
+Wspominam..., s. 12. 
+56 Archiwum Miasta Poznania, Kartoteka ewidencji ludności, sygn. 14372. 
+57 A. Nowak, op. cit., s. 48. 
+58 B. Chrzanowski, Ksawery Zakrzewski 15.11.1876 - 19. XI. 1915. "Czuj Duch", 1932, R. VI, 
+nr 5, s. 4. Autor podał błędną (późniejszą o jeden dzień) datę zgonu Zakrzewskiego, spo- 
+tykaną także w innych opracowaniach. Trudno wskazać na pierwotne źródło tego błędu. 
+59 B. Wietrzychowski, Tablice historyczne dla ulic Poznania o nazwach osobowych, "Kronika 
+Miasta Poznania", 1938, R. XVI, s. 383. 
+60 Z. Zakrzewski, Wspominam..., s. 338-339.; A. Nowak: op. cit., s. 48-49. Cytowany 
+w tym opracowaniu hymn szczepu harcerskiego, wspominający o Zakrzewskim, jest nie- 
+stety przykładem grafomanii. 
+
+BOLESŁAW KRYSIEWICZ, LEKARZ PEDIATRA 
+I SPOŁECZNIK, PREZES NACZELNEJ RADY LUDOWEJ 
+ANNA MARCINIAK 
+B olesław Krysiewicz urodził się 11 września 1862 r. w Czarnkowie jako syn 
+kupca i rzemieślnika Ignacego oraz Apolonii z Willantów. W wieku niespeł- 
+na dziesięciu lat stracił ojca i w lutym 1872 roku razem z matką i siostrą Heleną 
+przybył do Poznania, gdzie zaopiekowała się nimi rodzina ojca. Zamieszkali 
+wówczas w domu Elżbiety i Jana Krysiewiczów przy Świętym Marcinie, gdzie 
+także mieścił się sklep Jana Krysiewicza (1818-1896), kupca i przemysłowca, 
+właściciela fabryki mosiądzu i kotłów parowych. Prawdopodobnie owdowiała 
+Apolonia Krysiewicz otrzymała jakieś zajęcie w tym sklepie lub w domu Krysie- 
+wiczów. W roku 1872 Bolesław rozpoczął naukę w Gimnazjum św. Marii Mag- 
+daleny w Poznaniu. Należał do Towarzystwa Tomasza Zana, gdzie wkrótce 
+został kierownikiem jednego z kółek samokształceniowych. W gimnazjum za- 
+przyjaźnił się ze starszym o rok Bernardem Chrzanowskim, wówczas redakto- 
+rem rękopiśmiennego "Miesięcznika" TTZ, późniejszym słynnym adwokatem, 
+posłem do parlamentu niemieckiego, działaczem Ligi Narodowej, kuratorem 
+Okręgu Szkolnego Poznańskiego i senatorem RP. 
+W roku 1881 zdał maturę i rozpoczął studia na Wydziale Lekarskim Uniwer- 
+sytetu Wrocławskiego. Zainteresował się wówczas szczególnie fizjologią, wykła- 
+daną tam przez sławnego fizjologa Heidenkeina. Podczas studiów brai czynny 
+udział w życiu kulturalnym polskiej młodzieży akademickiej: został członkiem 
+Towarzystwa Literacko-Słowiańskiego działającego przy Uniwersytecie Wrocła- 
+wskim. Młodzież polska, studiująca wówczas na uniwersytetach niemieckich, 
+zakładała niezliczone stowarzyszenia i organizacje samokształceniowe i patrio- 
+tyczne. Bolesław Krysiewicz działał zwłaszcza w Sekcji Medycznej, istniejącej 
+przy wspomnianym Towarzystwie Literacko-Słowiańskim od roku 1873. Sekcja 
+ta miała zapoznawać studentów medycyny z polską terminologią lekarską oraz 
+
+152 
+Anna Marciniak 
+Ryc. l. Bolesław Krysiewicz. 
+Fot. przed 1914 r. 
+z polską literaturą medycznąl. Towa- 
+rzystwo Literacko-Słowiańskie we Wro- 
+cławiu zostało rozwiązane przez rząd 
+pruski krótko po IV Zjeździe Lekarzy 
+i Przyrodników Polskich, który odbył 
+się w 1884 roku w Poznaniu. Na zjeź- 
+dzie tym poznańscy członkowie To- 
+warzystwa Literacko- Słowiańskiego, 
+wśród nich także Bolesław Krysiewicz, 
+uczestniczyli w pracach komitetu orga- 
+.. . . 
+nlzacyjnego, pomagając w przyjmowa- 
+niu przybyłych na zjazd rodaków ze 
+wszystkich trzech zaborów 2 . 
+Po wrocławskiej uczelni Krysiewicz 
+studiował następnie na uniwersytetach 
+w Wiirzburgu i Gryfu, gdzie ukończył 
+studia lekarskie w roku 1886. Dyplom 
+doktora medycyny uzyskał na uniwer- 
+sytecie w Lipsku w roku 1887, na pod- 
+stawie pracy z dziedziny urologii Bei- 
+trag zur lndikation der Drainage der 
+miinnlichen Harnblase A. 

--- a/tests/fixtures/test_002.txt
+++ b/tests/fixtures/test_002.txt
@@ -1,0 +1,200 @@
+Mieszka i ona także została oświeconą, bo gdy on przyjął wiarę, naród polski ura- 
+towany został od śmierci w pogaństwie". Pomińmy dalsze zdania kronikarza, 
+w których rozwija dalej wątek cudownego uzdrowienia chłopięcego księcia, ja- 
+ko prefiguracji i zwiastuna nawrócenia Polski na chrześcijaństwo, gdyż nie za- 
+
+8 
+Jacek Wiesiołowski 
+wiera on żadnych medycznych aspektów, a jak sam wyżej napisał: "wówczas 
+inaczej to mogło być rozumiane". 
+Bardziej interesujący jest następny rozdział kroniki: Jak Mieszko pojął za żonę 
+Dąbrówkę, wskazujący, iż uzdrowiony Mieszko nie tylko rozpoznał ojcowskich 
+dostojników. "Mieszko objąwszy księstwo zaczął dawać dowody zdolności umy- 
+słu i sił cielesnych i coraz częściej napastować ludy [sąsiednie] dookoła. Dotych- 
+czas jednak w takich pogrążony był błędach pogaństwa, że wedle swego zwy- 
+czaju siedmiu żon zażywał". Okazuje się, że wyleczony Mieszko, dotąd tylko 
+dotykiem, węchem i słuchem rozpoznający świat, po odzyskaniu wzroku odkrył 
+istnienie kobiet i ich uroków. Co więcej, zauroczony kobietami stał się poligami- 
+stą, gdy jego przodkowie jak pradziad Piast czy ojciec Siemomysł zadowalali się 
+jedną żoną. Czy i jaki istniał związek między zaaplikowaną chłopcu przez leka- 
+rza kuracją a nadmiarem "sił cielesnych" młodego Mieszka, nie wiemy. 
+"W końcu zażądał w małżeństwo jednej bardzo dobrej chrześcijanki z Czech, 
+imieniem Dąbrówka. Lecz ona odmówiła poślubienia go, jeśli nie zarzuci owego 
+zdrożnego obyczaju i nie przyrzeknie zostać chrześcijaninem. Gdy zaś on [na to] 
+przystał, że porzuci ów zwyczaj pogański i przyjmie sakramenta wiary chrześci- 
+jańskiej, pani owa przybyła do Polski z wielkim orszakiem [ dostojników] świec- 
+kich i duchownych, ale nie pierwej podzieliła z nim łoże małżeńskie, aż powoli 
+a pilnie zaznajamiając się z obyczajem chrześcijańskim i prawami kościelnymi, 
+wyrzekł się błędów pogaństwa i przeszedł na łono matki-Kościoła". 
+Czy cnotliwa chrześcijanka mogła zastąpić Mieszkowi obcowanie z siedmioma 
+żonami, gdy wreszcie "podzieliła z nim łoże małżeńskie"? Złośliwy czeski kroni- 
+karz Kosmas, powtarzając dworską plotkę pisał o Dąbrówce z okazji jej śmierci: 
+"była ponad miarę bezwstydna, kiedy poślubiała księcia polskiego będąc już ko- 
+bietą podeszłego wieku [!], zdjęła ze swej głowy zawój i nałożyła panieński wia- 
+nek, co było wielkim głupstwem tej kobiety". 
+Żadna z późniejszych polskich kronik nie poświęca tyle miejsca ślepocie 
+Mieszka i jego żonom. Jedynie w swym komentarzu mistrz Wincenty w pocz. 
+XIII wieku zwraca uwagę na symboliczne znaczenie liczby siedem, choć nie pre- 
+cyzuje czy dotyczy ono lat ślepoty czy jeszcze większej ilości żon pogańskich 
+księcia. 
+Historyk literatury zauważy w opisanych przez Galla wydarzeniach wyraźne 
+związki z literaturą zachodniej Europy. Cudowne wyleczenie młodego księcia ze 
+ślepoty i niemoty występuje już w opowieściach o księciu Anglów Offie, przeka- 
+zanych przez duńskich kronikarzy z końca XII w., wcześniejsze ślady tej fabuły 
+nie były dotąd poszukiwane. Wielożeństwo pogańskich władców było powszech- 
+nie opisywane w literaturze (liczni sułtani Babilonu i emirowie saraceńscy) jako 
+cecha pogańska i saraceńska i dlatego nią został obdarzony nasz Mieszko. 
+Historyk medycyny z żalem stwierdzi, że kronikarza, poszukującego na siłę 
+prefiguracji chrystianizacji Polski, nie zainteresował aspekt medyczny choroby 
+księcia, nie wiemy, jaki był przebieg choroby, objawy, rozpoznanie i wreszcie ja- 
+ka kuracja była tak skuteczna. Galla Anonima nie zainteresowała osoba lekarza, 
+lecz wynik procesu leczenia, dlatego zamiast konkretnej osoby u początków pol- 
+skiej medycyny mamy nieznanego okulistę Mieszka I, Okulistę-Anonima. 
+
+MISTRZ MIKOŁAJ - NAJSTARSZY ZNANY LEKARZ 
+POZNAŃSKI 
+TOMASZ ruREK 
+W ielki poeta angielski XIV wieku Geoffrey Chaucer w swych Opowieściach 
+kanterberyjskich wymienia lekarza wśród charakterystycznych figur, repre- 
+zentujących różne grupy społeczne i zawodowe. Podobnie włoski dominikanin 
+Jakub de Cessolis w swym poczytnym dziełku na temat szachów umieszcza leka- 
+rza wśród ośmiu zawodów, których przedstawicieli symbolizować mają szacho- 
+we pionki. Uczeni medycy stanowili więc grupę wyraźnie obecną w społecznej 
+świadomości ówczesnych ludzi Zachodu. N awet jednak w najbardziej zaawan- 
+sowanych cywilizacyjne krajach - Italii czy południowej Francji - liczba lekarzy 
+legitymujących się uniwersyteckim wykształceniem była znikoma wobec potrzeb 
+ogółu ludności. Tym bardziej w krajach leżących, jak Polska, z dala od czołowych 
+ośrodków naukowych i słabiej zurbanizowanych. Czy więc średniowieczny Po- 
+lak chodził do lekarza? Lekarzy z naukowym cenzusem spotkać można było tyl- 
+ko w miastach i to tych większych. W mniejszych rolę służby zdrowia pełnili do- 
+morosłego chowu balwierze, zajmujący się nie tylko zabiegami higienicznymi 
+czy prostymi sprawami chirurgicznymi, lecz także leczącymi nawet trudne przy- 
+padki. To oni obsługiwali zapewne większość ludności, także z okolicznych wsi. 
+Niewiele wiemy o warunkach świadczenia tych usług. Tylko wyjątkowo znajdu- 
+jemy o nich wzmianki rodzaju następującego kontraktu. Oto w 1448 roku Luch- 
+na, żona Mikołaja z Kurowa, z drobnej podkaliskiej szlachty, zobowiązała się 
+zapłacić balwierzowi Stefanowi z Kalisza "za leczenie" (racione medicine et medica- 
+menti) swego syna Macieja; przypadek musiał być chyba skomplikowany, skoro 
+zastrzegano, że balwierz otrzyma 2 kopy groszy, "jeżeli Maciej zostanie wyle- 
+czony, ajeśli, co oby nie nastąpiło, umrze, wtedy Stefan ma dostać za swe lecze- 
+nie tylko 1 kopę groszy i nic więcej". 
+
+10 
+Tomasz Jurek 
+Spotykamy jednak w średniowiecznej Polsce także lekarzy uczonych, kształ- 
+conych na zagranicznych uniwersytetach. Ich imiona wymieniane są po raz 
+pierwszy w XIII wieku. W drugiej połowie tego stulecia rozgłos zdobył brat Mi- 
+kołaj z zakonu dominikanów, znany za granicą jako Mikołaj z Polski. Studiował 
+w południowo francuskim Montpellier, najważniejszym ówcześnie europejskim 
+ośrodku myśli medycznej. Bawił tam podobno 20, czy nawet ponad 30 lat, zy- 
+skując znaczną sławę. Pozostawił szereg teoretycznych pism, w których nawią- 
+zywał do modnych wtedy trendów medycyny "naturalnej", odwołującej się do 
+leczniczych sił przyrody ożywionej. Te same metody stosował też w praktyce. 
+Współczesny rocznikarz krakowski opisuje mianowicie pod 1278 rokiem, jak to 
+"wystąpił pewien zakonnik imieniem Mikołaj z zakonu kaznodziejskiego [domi- 
+nikanów], z urodzenia Niemiec, który uczył ludzi na wszystkie choroby jeść wę- 
+że, jaszczurki i żaby". Metody Mikołaja budziły zdziwienie: "Nigdy nie oglądał 
+moczu chorego, lecz miał pewne zamknięte woreczki. Co było w nich zamknię- 
+te, nie pozwalał zaglądać. Wieszał je nad chorymi na noc. Kto się od tego pocił 
+i miał senne widzenia, ten zostawał uleczony". Sam fakt, że działalność niekon- 
+wencjonalnego medyka opisana została na kartach rocznika - obok ważnych za- 
+pisów o królach, książętach i biskupach - świadczy o tym, że zyskać on musiał 
+nie małą popularność. Nawet "pewni bracia z zakonu kaznodziejskiego, poucze- 
+ni przez niego, zaczęli jeść węże". Co gorsza, "także pan Leszek [Czarny] książę 
+sieradzki [cierpiący, jak wiadomo skądinąd, na impotencję] ze swą żoną Gryfina 
+z zalecenia tegoż dominikanina zaczęli zjadać węże, jaszczurki i żaby, z którego 
+to powodu cały lud nabrał do nich odrazy, choć były im bardzo pomocne". Wie- 
+rzono więc w skuteczność osobliwej diety, czując wszakże do niej zarazem 
+obrzydzenie. Co więcej, rocznikarz wytacza przeciwko medykowi poważniejsze 
+zastrzeżenia: "Ludzie łapali gołymi rękami węże w imię tego Mikołaja, ale nie 
+w imię Chrystusa. Bo kto chciałby wziąć węża w imię Chrystusa, tego, choćby 
+
+Mistrz Mikołaj - naj starszy znany lekarz poznański 
+11 
+miał rękę okrytą rękawicą, natychmiast wąż ukąsił". Sugestia jest aż nadto przej- 
+rzysta: obrzydliwe praktyki uczonego medyka niewiele mają wspólnego z praw- 
+dziwą wiarą chrześcijańską. 
+Nie mamy pewności, gdzie działał w Polsce uczony Mikołaj; przypuszcza się, 
+że w Sieradzu - tam rezydował wtedy książę Leszek i był tam też konwent do- 
+minikański - ale najpewniej mógł to być sam stołeczny Kraków, skoro osobliwe 
+praktyki tego lekarza opisał dokładnie tamtejszy rocznikarz (a Leszek Czarny po- 
+zostawał w znakomitych stosunkach z krakowskim Bolesławem Wstydliwym). 
+Wielkopolska także miała podówczas swojego uczonego medyka. Żył niejako 
+w cieniu wybitnego imiennika - bo również nosił popularne wtedy imię Mikołaj. 
+O ile krakowski Mikołaj znany jest nam głównie poprzez swe traktaty i cytowa- 
+ną relację o osobliwych sposobach leczenia, o tyle wiedzę o Mikołaju wielkopol- 
+skim czerpiemy wyłącznie z krótkich wzmianek w dokumentach. Chronologia 
+tych wzmianek - pochodzących z ostatniej ćwierci XIII i początków XN w. - nie 
+wyklucza zresztą utożsamienia obydwu Mikołajów. Pogląd taki do dziś przewi- 
+ja się w specjalistycznej literaturze historyczno-medycznej. Identyfikacja taka nie 
+wydaje się jednak możliwa. Uczony propagator gadziej diety był, przypomnij- 
+my, "z urodzenia Niemcem" - a więc pochodził prawdopodobnie z miejscowego 
+mieszczaństwa. O wielkopolskim Mikołaju wiemy natomiast, że dziedziczył po 
+ojcu dobra ziemskie (podpoznańskie Daszewice oraz nieodgadnione "Sweczke"). 
+Pochodził zatem niewątpliwie z rodziny rycerskiej i prawie na pewno uważać go 
+trzeba za rodowitego Polaka. Posiadanie majątków ziemskich wyklucza też oczy- 
+wiście możliwość przynależności do zakonu dominikanów. Co więcej, wiadomo, 
+że wielkopolski Mikołaj miał potomstwo, co również nie da się pogodzić z za- 
+konną profesją. 
+Nie potrafimy bliżej zidentyfikować rodziny lub rodu pochodzenia Mikołaja. 
+Daszewice sto lat później należały do szlachty z rodu Junoszów (noszącego 
+w herbie barana), przez ten czas mogło zajść wiele majątkowych zmian. Może 
+więc raczej należałoby wyprowadzać Mikołaja z rodu Łodziów (z łodzią w her- 
+bie): siedzieli oni w bliskim sąsiedztwie (Głuszyna, Rogalin, Mosina), a w samej 
+nazwie Daszewic pobrzmiewa imię Dasz, spotykane później u Łodziów Rogaliń- 
+skich. Łodziowie należeli w XIII w. do czołowego możnowładztwa Wielkopolski, 
+obsadzając najwyższe urzędy i gromadząc ogromne dobra. Nasz Mikołaj mógł 
+pochodzić z zamożnej rodziny - dwie wsie, które przypadły mu po ojcu, mogły 
+wszak stanowić część znacznie większego majątku, podzielonego między licz- 
+niejsze rodzeństwo. Nie wiemy też nic o młodości Mikołaja. Musiał ukończyć 
+jakieś studia uniwersyteckie. Wielokrotnie tytułował się potem magistrem. 
+Nie sposób jednak wyrokować, czy studiował - jak dominikański imiennik 
+- w Montpellier, czy w nie mniej słynącym z wiedzy medycznej Salerno, czy też 
+na innym jeszcze uniwersytecie; Polacy jeździli w XIII w. przeważnie do Paryża 
+lub Bolonii, ale zgłębiali tam głównie teologię bądź prawo. Przypuszczać trzeba, 
+że Mikołaj wcześniej pobierał nauki w swej parafialnej szkole w Głuszynie (do tej 
+właśnie parafii należały Daszewice), czy potem kształcił się w którejś z reprezen- 
+tujących chyba wyższy poziom szkół w Poznaniu: przy katedrze bądź przy farze 
+św. Marii Magdaleny. 
+
+12 
+Tomasz Jurek 
+Niejasne pozostają też po- 
+czątki publicznej działalności na- 
+szego Mikołaja, już po powrocie 
+z naukowych wojaży. Najstarsze 
+wzmianki źródłowe budzą wąt- 
+pliwości, czy wiązać je można 
+z jego osobą. Jakiś "magister Mi- 
+kołaj lekarz" (magister Nicolaus 
+phisicus) pojawił się 8 sierpnia 
+1271 r. jako świadek dokumentu 
+księcia wielkopolskiego Bolesła- 
+wa Pobożnego, wystawionego 
+w kujawskim Włocławku. Wy- 
+daje się, choć konstrukcja listy 
+świadków nie jest całkiem czytel- 
+na, że chodzi tu o kanonika kapi- 
+tuły katedralnej we Włocławku. 
+Wyklucza to możliwość upatrywa- 
+nia w nim znanego nam już kra- 
+kowskiego dominikanina (zwią- 
+zanego jednak, jak pamiętamy, 
+z książętami kujawskimi) - jako 
+zakonnik nie mógł być zarazem 
+kanonikiem; rozpoczął zresztą 
+swą sensacyjną działalność do- 
+piero kilka lat później. Mógł być 
+natomiast we Włocławku nasz 
+Mikołaj z Daszewic. Całe życie 
+służył potem kolejnym władcom 
+wielkopolskim, więc możliwe, że przybył do Włocławka wraz z Bolesławem Po- 
+bożnym, który został zresztą właśnie wtedy panem części Kujaw. Protekcji wiel- 
+kopolskiego księcia zawdzięczałby też najpewniej Mikołaj uzyskanie kanonii 
+włocławskiej. Możliwe zresztą, że zatrudniony był w książęcej kancelarii: wszyst- 
+kie dokumenty Bolesława dla biskupstwa włocławskiego (a także kilka innych 
+dla wielkopolskich odbiorców) redagował jeden człowiek - może właśnie nasz 
+Mikołaj, któremu sztuka układania pism kancelaryjnych nie była, jakjeszcze zo- 
+baczymy, bynajmniej obca. Trudno jednak o pewność, czy ów kanonik-lekarz 
+nie był w ogóle inną zgoła osobistością, jakimś nieznanym poza tym bliżej Kuja- 
+wianinem. Imię Mikołaj należało wszak wówczas do najbardziej popularnych. 

--- a/tidy.py
+++ b/tidy.py
@@ -14,6 +14,10 @@ import logging
 
 
 class TextTidy(object):
+    EMPTY_HEADING = '\x1f\x1d\x0b'
+    PAGE_NUMBER = '\x0c'
+    PAGE_BREAK = '\x1f\x1d'
+
     def __init__(self, _in):
         self._in = _in
         self._logger = logging.getLogger(self.__class__.__name__)
@@ -35,13 +39,13 @@ class TextTidy(object):
             line = line.strip()
 
             # empty headings
-            if line.startswith('\x1f\x1d\x0b'):
+            if line.startswith(self.EMPTY_HEADING):
                 pass
             # page numbers
-            elif line.startswith('\x0c'):
+            elif line.startswith(self.PAGE_NUMBER):
                 continue
             # page breaks - headings
-            elif line.startswith('\x1f\x1d'):
+            elif line.startswith(self.PAGE_BREAK):
                 line = line[2:]  # remove magic characters
 
                 # ignore empty headings followed by the title


### PR DESCRIPTION
```xml
<sphinx:schema>
        <sphinx:field name="title"></sphinx:field>
        <sphinx:field name="chapter"></sphinx:field>
        <sphinx:field name="content"></sphinx:field>
        <sphinx:attr type="string" name="title"></sphinx:attr>
        <sphinx:attr type="string" name="chapter"></sphinx:attr>
        <sphinx:attr type="string" name="content"></sphinx:attr>
        <sphinx:attr type="int" name="published_year"></sphinx:attr>
        <sphinx:attr type="int" name="publication_id"></sphinx:attr>
        <sphinx:attr type="int" name="document_id"></sphinx:attr>
</sphinx:schema>
```

```xml
<sphinx:document id="6554">
        <chapter>Z RACHUNKÓW FOLWARKU ŻEGRZE-RATAJE I RATAJE (1600-1601,1625-1626,1628-1629)</chapter>
        <published_year>2001</published_year>
        <title>Kronika Miasta Poznania 2001 Nr3 ; Rataje i Żegrze</title>
        <publication_id>106644</publication_id>
        <content>Z RACHUNKÓW FOLWARKU ŻEGRZE-RATAJE I RATAJE (1600-1601,1625-1626,1628-1629) 
WYDAŁA ZOFIA WOJCIECHOWSKA 
W 1599 roku miasto Poznań wykupiło z zastawu część gruntów wsi Rataje, a pozostałą część otrzymało w drodze darowizny. W latach 1599-1629 Rataje pozostawały w bezpośrednim władaniu i użytkowaniu miasta, a po
 1629 roku zostały przez miasto wydzierżawione. Dzieje Zegrza z kolei były ściśle związane z dziejami Rataj - w latach 1600-20 ich rachunki prowadzono łącznie, gdyż tworzyłyjeden folwark. Dla lat 1621-24 rac
hunków nie wytworzono lub nie zachowały się, natomiast rachunki za lata 1625-29 obejmowały sam tylko folwark Rataje.
Wkrótce po wykupieniu wsi Rataje-Żegrze folwark oddano w administrację.
...
```